### PR TITLE
chore: update golangci-lint to v1.46.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ BUILD_DIR := build
 .PHONY: tools
 tools:
 ifeq (,$(wildcard ./.bin/golangci-lint*))
-	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b .bin/ v1.44.0
+	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b .bin/ v1.46.0
 else
 	@echo "==> Required tooling is already installed"
 endif


### PR DESCRIPTION
This PR bumps golangci linter to solve the issue with Go 1.18.