### PR TITLE
docs: fix broken badge in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Xelon SDK for Go
 
-[![Build](https://github.com/Xelon-AG/xelon-sdk-go/actions/workflows/unit_tests.yml/badge.svg)](https://github.com/Xelon-AG/xelon-sdk-go/actions)
+[![Build](https://github.com/Xelon-AG/xelon-sdk-go/actions/workflows/unit_tests.yaml/badge.svg)](https://github.com/Xelon-AG/xelon-sdk-go/actions)
 [![Go Report Card](https://goreportcard.com/badge/github.com/Xelon-AG/xelon-sdk-go)](https://goreportcard.com/report/github.com/Xelon-AG/xelon-sdk-go)
 [![GoDoc](https://img.shields.io/badge/pkg.go.dev-doc-blue)](http://pkg.go.dev/github.com/Xelon-AG/xelon-sdk-go)
 


### PR DESCRIPTION
This PR fixes missing badge for unit tests in readme file.
After renaming workflow files svg link was broken.