### PR TITLE
feat: add client_id support for ip ranges

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/Xelon-AG/xelon-sdk-go
 
 go 1.19
 
-require github.com/stretchr/testify v1.8.0
+require github.com/stretchr/testify v1.8.1
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -5,9 +5,11 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
+github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/xelon/client.go
+++ b/xelon/client.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	libraryVersion = "0.7.0"
+	libraryVersion = "0.8.0"
 
 	defaultBaseURL   = "https://hq.xelon.ch/api/service/"
 	defaultMediaType = "application/json"
@@ -27,8 +27,9 @@ type Client struct {
 	httpClient *http.Client // HTTP client used to communicate with the API.
 
 	BaseURL   *url.URL // Base URL for API requests. BaseURL should always be specified with a trailing slash.
-	UserAgent string   // User agent used when communicating with Xelon API.
+	ClientID  string   // ClientID for IP ranges.
 	Token     string   // Token for Xelon API.
+	UserAgent string   // User agent used when communicating with Xelon API.
 
 	common service // Reuse a single struct instead of allocating one for each service on the heap.
 
@@ -50,6 +51,13 @@ func WithBaseURL(baseURL string) ClientOption {
 	return func(client *Client) {
 		parsedURL, _ := url.Parse(baseURL)
 		client.BaseURL = parsedURL
+	}
+}
+
+// WithClientID configures Client to use "X-User-Id" http header by all API requests.
+func WithClientID(clientID string) ClientOption {
+	return func(client *Client) {
+		client.ClientID = clientID
 	}
 }
 
@@ -137,6 +145,10 @@ func (c *Client) NewRequest(method, urlStr string, body interface{}) (*http.Requ
 	req.Header.Set("Accept", defaultMediaType)
 	req.Header.Set("Content-Type", defaultMediaType)
 	req.Header.Set("User-Agent", c.UserAgent)
+
+	if c.ClientID != "" {
+		req.Header.Set("X-User-Id", c.ClientID)
+	}
 
 	return req, nil
 }

--- a/xelon/client_test.go
+++ b/xelon/client_test.go
@@ -65,6 +65,14 @@ func TestClient_WithBaseURL(t *testing.T) {
 	assert.Equal(t, expectedBaseURL, client.BaseURL)
 }
 
+func TestClient_WithClientID(t *testing.T) {
+	client := NewClient("auth-token",
+		WithClientID("custom-client-id"),
+	)
+
+	assert.Equal(t, "custom-client-id", client.ClientID)
+}
+
 func TestClient_WithHTTPClient(t *testing.T) {
 	httpClient := &http.Client{Timeout: 2 * time.Second}
 	client := NewClient("auth-token",


### PR DESCRIPTION
This PR adds client_id support for IP ranges. This option will add `X-User-Id` HTTP header to all requests.