### PR TITLE
chore(gh-actions): fix permissions issue for cache directories

### DIFF
--- a/.github/goreleaser.yaml
+++ b/.github/goreleaser.yaml
@@ -1,3 +1,5 @@
+version: 2
+
 project_name: xelon-sdk-go
 
 before:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -22,7 +22,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: "go.mod"
-          cache: true
+
 
       - name: Install tools
         run: make tools
@@ -31,9 +31,9 @@ jobs:
         run: make test
 
       - name: GoReleaser
-        uses: goreleaser/goreleaser-action@v3
+        uses: goreleaser/goreleaser-action@v6
         with:
-          args: release -f .github/goreleaser.yaml --rm-dist
+          args: release -f .github/goreleaser.yaml --clean
           distribution: goreleaser
           version: latest
         env:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -25,7 +25,10 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: "go.mod"
-          cache: true
+
+      - name: Fix permissions for cache directories
+        run: |
+          chmod -R 0755 ~/.cache/go-build ~/go/pkg/mod || true
 
       - name: Set up cache
         uses: actions/cache@v4


### PR DESCRIPTION
This PR fixes issues with missing permissions for cache directories in `actions/cache`.