### PR TITLE
fix(devices): add custom unmarshaller for device network

### DIFF
--- a/xelon/devices.go
+++ b/xelon/devices.go
@@ -2,10 +2,12 @@ package xelon
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"iter"
 	"net/http"
+	"net/netip"
 )
 
 const deviceBasePath = "devices"
@@ -31,9 +33,49 @@ type Device struct {
 }
 
 type DeviceNetwork struct {
-	Connected bool   `json:"isConnected,omitempty"`
-	ID        string `json:"identifier,omitempty"`
-	IPAddress string `json:"ip,omitempty"`
+	Connected   bool                     `json:"isConnected,omitempty"`
+	ID          string                   `json:"identifier,omitempty"`
+	IPAddresses DeviceNetworkIPAddresses `json:"ip,omitempty"`
+}
+
+type DeviceNetworkIPAddresses []netip.Addr
+
+func (a *DeviceNetworkIPAddresses) UnmarshalJSON(data []byte) error {
+	// normalize null and missing to empty slice
+	if string(data) == "null" {
+		*a = []netip.Addr{}
+		return nil
+	}
+
+	// accept string or array that API might sent
+	var raw []string
+	if err := json.Unmarshal(data, &raw); err != nil {
+		var singleIPAddress string
+		if err := json.Unmarshal(data, &singleIPAddress); err != nil {
+			return fmt.Errorf("ip must be string or []string: %w", err)
+		}
+		raw = []string{singleIPAddress}
+	}
+
+	// validate entries and reject the whole payload on any bad value
+	ipAddresses := make([]netip.Addr, 0, len(raw))
+	seen := make(map[netip.Addr]bool, len(raw))
+	for i, s := range raw {
+		addr, err := netip.ParseAddr(s)
+		if err != nil {
+			return fmt.Errorf("ip[%d] %q: %w", i, s, err)
+		}
+		if addr.IsUnspecified() {
+			return fmt.Errorf("ip[%d] %q: unspecified address not allowed", i, s)
+		}
+		if seen[addr] {
+			return fmt.Errorf("ip[%d] %q: duplicate", i, s)
+		}
+		seen[addr] = true
+		ipAddresses = append(ipAddresses, addr)
+	}
+	*a = ipAddresses
+	return nil
 }
 
 type DeviceStorage struct {

--- a/xelon/devices_test.go
+++ b/xelon/devices_test.go
@@ -1,0 +1,82 @@
+package xelon
+
+import (
+	"encoding/json"
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDevices_DeviceNetworkIPAddresses_UnmarshalJSON(t *testing.T) {
+	type testCase struct {
+		input     string
+		expect    []netip.Addr
+		expectErr bool
+	}
+	tests := map[string]testCase{
+		"single string": {
+			input:     `"10.0.0.1"`,
+			expect:    []netip.Addr{netip.MustParseAddr("10.0.0.1")},
+			expectErr: false,
+		},
+		"array of strings": {
+			input: `["10.0.0.1", "2001:db8::1"]`,
+			expect: []netip.Addr{
+				netip.MustParseAddr("10.0.0.1"),
+				netip.MustParseAddr("2001:db8::1"),
+			},
+			expectErr: false,
+		},
+		"empty array": {
+			input:     `[]`,
+			expect:    []netip.Addr{},
+			expectErr: false,
+		},
+		"null becomes empty": {
+			input:     `null`,
+			expect:    []netip.Addr{},
+			expectErr: false,
+		},
+		"invalid ip rejected": {
+			input:     `"not-an-ip"`,
+			expect:    nil,
+			expectErr: true,
+		},
+		"one bad entry rejects whole list": {
+			input:     `["10.0.0.1", "not-an-ip"]`,
+			expect:    nil,
+			expectErr: true,
+		},
+		"wrong type rejected": {
+			input:     `42`,
+			expect:    nil,
+			expectErr: true,
+		},
+		"unspecified rejected": {
+			input:     `"0.0.0.0"`,
+			expect:    nil,
+			expectErr: true,
+		},
+		"duplicates rejected": {
+			input:     `["10.0.0.1", ""10.0.0.1"]`,
+			expect:    nil,
+			expectErr: true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			var actual DeviceNetworkIPAddresses
+			err := json.Unmarshal([]byte(test.input), &actual)
+
+			if test.expectErr {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.ElementsMatch(t, test.expect, actual)
+		})
+	}
+}


### PR DESCRIPTION
This PR fixes the bug with backend API inconsistency for `DeviceNetwork`: "ip" can be string or array of string.