### PR TITLE
fix(object-storages): fix marshalling for create/update because of backend changes

### DIFF
--- a/xelon/object_storages.go
+++ b/xelon/object_storages.go
@@ -45,6 +45,10 @@ type ObjectStorageUserListOptions struct {
 	ListOptions
 }
 
+type objectStorageUserRoot struct {
+	ObjectStorageUser *ObjectStorageUser `json:"data"`
+}
+
 type objectStorageUsersRoot struct {
 	ObjectStorageUsers []ObjectStorageUser `json:"data"`
 	Meta               *Meta               `json:"meta,omitempty"`
@@ -116,13 +120,16 @@ func (s *ObjectStoragesService) CreateUser(ctx context.Context, createRequest *O
 		return nil, nil, err
 	}
 
-	user := new(ObjectStorageUser)
-	resp, err := s.client.Do(ctx, req, user)
+	root := new(objectStorageUserRoot)
+	resp, err := s.client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
+	if root.ObjectStorageUser == nil {
+		return nil, resp, errors.New("failed to create object storage user: response data is empty")
+	}
 
-	return user, resp, nil
+	return root.ObjectStorageUser, resp, nil
 }
 
 // UpdateUser changes a object storage user.
@@ -140,13 +147,16 @@ func (s *ObjectStoragesService) UpdateUser(ctx context.Context, objectStorageUse
 		return nil, nil, err
 	}
 
-	user := new(ObjectStorageUser)
-	resp, err := s.client.Do(ctx, req, user)
+	root := new(objectStorageUserRoot)
+	resp, err := s.client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
+	if root.ObjectStorageUser == nil {
+		return nil, resp, errors.New("failed to update object storage user: response data is empty")
+	}
 
-	return user, resp, nil
+	return root.ObjectStorageUser, resp, nil
 }
 
 // DeleteUser removes object storage user identified by id.

--- a/xelon/object_storages_test.go
+++ b/xelon/object_storages_test.go
@@ -71,6 +71,44 @@ func TestObjectStorages_CreateUser(t *testing.T) {
 	assert.Equal(t, expectedUser, actualUser)
 }
 
+func TestObjectStorages_CreateUser_MissingData(t *testing.T) {
+	setup()
+	defer teardown()
+
+	type testCase struct {
+		responseBody string
+	}
+	tests := map[string]testCase{
+		"missing data": {
+			responseBody: `{"message":"S3 user successfully created"}`,
+		},
+		"null data": {
+			responseBody: `{"data":null,"message":"S3 user successfully created"}`,
+		},
+	}
+
+	var responseBody string
+	mux.HandleFunc("POST /object-storages/users", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		_, _ = w.Write([]byte(responseBody))
+	})
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			responseBody = test.responseBody
+
+			actualUser, resp, err := client.ObjectStorages.CreateUser(ctx, &ObjectStorageUserCreateRequest{
+				Name:    "test-user-0",
+				QuotaGB: 200,
+			})
+
+			assert.Nil(t, actualUser)
+			assert.NotNil(t, resp)
+			assert.EqualError(t, err, "failed to create object storage user: response data is empty")
+		})
+	}
+}
+
 func TestObjectStorages_UpdateUser(t *testing.T) {
 	setup()
 	defer teardown()
@@ -93,4 +131,42 @@ func TestObjectStorages_UpdateUser(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
 	assert.Equal(t, expectedUser, actualUser)
+}
+
+func TestObjectStorages_UpdateUser_MissingData(t *testing.T) {
+	setup()
+	defer teardown()
+
+	type testCase struct {
+		responseBody string
+	}
+	tests := map[string]testCase{
+		"missing data": {
+			responseBody: `{"message":"S3 user successfully edited"}`,
+		},
+		"null data": {
+			responseBody: `{"data":null,"message":"S3 user successfully edited"}`,
+		},
+	}
+
+	var responseBody string
+	mux.HandleFunc("PUT /object-storages/users/00000000-0000-0000-0000-000000000000", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		_, _ = w.Write([]byte(responseBody))
+	})
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			responseBody = test.responseBody
+
+			actualUser, resp, err := client.ObjectStorages.UpdateUser(ctx, "00000000-0000-0000-0000-000000000000", &ObjectStorageUserUpdateRequest{
+				Name:    "test-user-0__updated",
+				QuotaGB: 200,
+			})
+
+			assert.Nil(t, actualUser)
+			assert.NotNil(t, resp)
+			assert.EqualError(t, err, "failed to update object storage user: response data is empty")
+		})
+	}
 }

--- a/xelon/testdata/objectstorages_create_user_success.json
+++ b/xelon/testdata/objectstorages_create_user_success.json
@@ -1,14 +1,16 @@
 {
-  "identifier": "00000000-0000-0000-0000-000000000000",
-  "name": "test-user-0",
-  "createdAt": "2025-10-27T14:19:56+01:00",
-  "tokens": [
-    {
-      "identifier": "000000000000",
-      "accessKey": "ak_test_1234567890",
-      "secretKey": "sk_test_1234567890abcdef",
-      "createdAt": "2025-10-27T14:19:56+01:00"
-    }
-  ],
+  "data": {
+    "identifier": "00000000-0000-0000-0000-000000000000",
+    "name": "test-user-0",
+    "createdAt": "2025-10-27T14:19:56+01:00",
+    "tokens": [
+      {
+        "identifier": "000000000000",
+        "accessKey": "ak_test_1234567890",
+        "secretKey": "sk_test_1234567890abcdef",
+        "createdAt": "2025-10-27T14:19:56+01:00"
+      }
+    ]
+  },
   "message": "S3 user successfully created"
 }

--- a/xelon/testdata/objectstorages_update_user_success.json
+++ b/xelon/testdata/objectstorages_update_user_success.json
@@ -1,6 +1,8 @@
 {
-  "identifier": "00000000-0000-0000-0000-000000000000",
-  "name": "test-user-0__updated",
-  "createdAt": "2025-10-27T14:19:56+01:00",
+  "data": {
+    "identifier": "00000000-0000-0000-0000-000000000000",
+    "name": "test-user-0__updated",
+    "createdAt": "2025-10-27T14:19:56+01:00"
+  },
   "message": "S3 user successfully edited"
 }


### PR DESCRIPTION
This PR fixes issues with failed create/update method for object storage users. Backend now wraps object inside of `data` field.