### PR TITLE
feat(tenant-users): add new service to manage tenant users

### DIFF
--- a/xelon/client.go
+++ b/xelon/client.go
@@ -53,6 +53,7 @@ type Client struct {
 	SSHKeys              *SSHKeysService
 	Templates            *TemplatesService
 	Tenants              *TenantsService
+	TenantUsers          *TenantUsersService
 }
 
 type service struct {
@@ -156,6 +157,7 @@ func NewClient(token string, opts ...ClientOption) *Client {
 	c.SSHKeys = (*SSHKeysService)(&c.common)
 	c.Templates = (*TemplatesService)(&c.common)
 	c.Tenants = (*TenantsService)(&c.common)
+	c.TenantUsers = (*TenantUsersService)(&c.common)
 
 	return c
 }

--- a/xelon/tenant_users.go
+++ b/xelon/tenant_users.go
@@ -1,0 +1,263 @@
+package xelon
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+)
+
+const tenantUsersBasePath = "tenants/%s/users"
+
+// TenantUsersService handles communication with tenant user methods of the Xelon API.
+type TenantUsersService service
+
+// TenantUser represents a user that belongs to a Xelon tenant.
+type TenantUser struct {
+	Email       string                 `json:"email,omitempty"`
+	ID          string                 `json:"identifier,omitempty"`
+	JobTitle    string                 `json:"jobTitle,omitempty"`
+	Name        string                 `json:"name,omitempty"`
+	Permissions []TenantUserPermission `json:"permissions,omitempty"`
+	Phone       string                 `json:"phone,omitempty"`
+	Roles       []TenantUserRole       `json:"roles,omitempty"`
+	Surname     string                 `json:"surname,omitempty"`
+	TenantID    string                 `json:"tenantIdentifier,omitempty"`
+}
+
+type TenantUserRole struct {
+	DisplayName string `json:"friendlyName,omitempty"`
+	ID          int    `json:"id,omitempty"`
+	Name        string `json:"name,omitempty"`
+	Type        string `json:"type,omitempty"`
+}
+
+type TenantUserCreateRequest struct {
+	BusinessPhone         string   `json:"business_phone,omitempty"`
+	Email                 string   `json:"email"`
+	JobTitle              string   `json:"job_title,omitempty"`
+	Name                  string   `json:"name"`
+	Password              string   `json:"password"`
+	PasswordConfirmation  string   `json:"password_confirmation"`
+	Permissions           []string `json:"permissions,omitempty"`
+	Phone                 string   `json:"phone,omitempty"`
+	RequirePasswordChange bool     `json:"passwordShouldBeChanged"`
+	Roles                 []string `json:"roles,omitempty"`
+	SendWelcomeEmail      bool     `json:"welcomeEmail"`
+	Surname               string   `json:"surname"`
+}
+
+type TenantUserUpdateRequest struct {
+	BusinessPhone string `json:"business_phone,omitempty"`
+	JobTitle      string `json:"job_title,omitempty"`
+	Name          string `json:"name"`
+	Phone         string `json:"phone,omitempty"`
+	Surname       string `json:"surname"`
+}
+
+// TenantUserListOptions specifies the optional parameters to the TenantUsersService.List.
+type TenantUserListOptions struct {
+	Search string `url:"search,omitempty"`
+	Sort   string `url:"sort,omitempty"`
+
+	ListOptions
+}
+
+type tenantUserRoot struct {
+	TenantUser *TenantUser `json:"data,omitempty"`
+}
+
+type tenantUsersRoot struct {
+	TenantUsers []TenantUser `json:"data"`
+	Meta        *Meta        `json:"meta,omitempty"`
+}
+
+func (v TenantUser) String() string { return Stringify(v) }
+
+func (v TenantUserRole) String() string { return Stringify(v) }
+
+// List lists users that belong to a tenant.
+func (s *TenantUsersService) List(ctx context.Context, tenantID string, opts *TenantUserListOptions) ([]TenantUser, *Response, error) {
+	if tenantID == "" {
+		return nil, nil, fmt.Errorf("tenant id: %w", ErrEmptyArgument)
+	}
+
+	path, err := addOptions(fmt.Sprintf(tenantUsersBasePath, tenantID), opts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest(http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(tenantUsersRoot)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	if m := root.Meta; m != nil {
+		resp.Meta = m
+	}
+
+	return root.TenantUsers, resp, nil
+}
+
+// Get gets a tenant user by id.
+func (s *TenantUsersService) Get(ctx context.Context, tenantID, userID string) (*TenantUser, *Response, error) {
+	if tenantID == "" {
+		return nil, nil, fmt.Errorf("tenant id: %w", ErrEmptyArgument)
+	}
+	if userID == "" {
+		return nil, nil, fmt.Errorf("user id: %w", ErrEmptyArgument)
+	}
+
+	path := fmt.Sprintf("%v/%v", fmt.Sprintf(tenantUsersBasePath, tenantID), userID)
+	req, err := s.client.NewRequest(http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(tenantUserRoot)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	if root.TenantUser == nil {
+		return nil, resp, errors.New("tenant user data is empty")
+	}
+
+	return root.TenantUser, resp, nil
+}
+
+// Create creates a tenant user.
+func (s *TenantUsersService) Create(ctx context.Context, tenantID string, createRequest *TenantUserCreateRequest) (*TenantUser, *Response, error) {
+	if tenantID == "" {
+		return nil, nil, fmt.Errorf("tenant id: %w", ErrEmptyArgument)
+	}
+	if createRequest == nil {
+		return nil, nil, fmt.Errorf("payload: %w", ErrEmptyPayloadNotAllowed)
+	}
+
+	req, err := s.client.NewRequest(http.MethodPost, fmt.Sprintf(tenantUsersBasePath, tenantID), createRequest)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(tenantUserRoot)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	if root.TenantUser == nil {
+		return nil, resp, errors.New("tenant user data is empty")
+	}
+
+	return root.TenantUser, resp, nil
+}
+
+// Update updates a tenant user by id.
+func (s *TenantUsersService) Update(ctx context.Context, tenantID, userID string, updateRequest *TenantUserUpdateRequest) (*TenantUser, *Response, error) {
+	if tenantID == "" {
+		return nil, nil, fmt.Errorf("tenant id: %w", ErrEmptyArgument)
+	}
+	if userID == "" {
+		return nil, nil, fmt.Errorf("user id: %w", ErrEmptyArgument)
+	}
+	if updateRequest == nil {
+		return nil, nil, fmt.Errorf("payload: %w", ErrEmptyPayloadNotAllowed)
+	}
+
+	path := fmt.Sprintf("%v/%v", fmt.Sprintf(tenantUsersBasePath, tenantID), userID)
+	req, err := s.client.NewRequest(http.MethodPut, path, updateRequest)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(tenantUserRoot)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	if root.TenantUser == nil {
+		return nil, resp, errors.New("tenant user data is empty")
+	}
+
+	return root.TenantUser, resp, nil
+}
+
+// Delete deletes a tenant user by id.
+func (s *TenantUsersService) Delete(ctx context.Context, tenantID, userID string) (*Response, error) {
+	if tenantID == "" {
+		return nil, fmt.Errorf("tenant id: %w", ErrEmptyArgument)
+	}
+	if userID == "" {
+		return nil, fmt.Errorf("user id: %w", ErrEmptyArgument)
+	}
+
+	path := fmt.Sprintf("%v/%v", fmt.Sprintf(tenantUsersBasePath, tenantID), userID)
+	req, err := s.client.NewRequest(http.MethodDelete, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(ctx, req, nil)
+}
+
+type TenantUserPermission struct {
+	DisplayName string `json:"friendlyName,omitempty"`
+	ID          int    `json:"id,omitempty"`
+	Name        string `json:"name,omitempty"`
+	Type        string `json:"type,omitempty"`
+}
+
+type TenantUserPermissionsUpdateRequest struct {
+	ChildTenants []string `json:"childTenants,omitempty"`
+	Permissions  []string `json:"permissions"`
+	Roles        []string `json:"roles"`
+}
+
+func (v TenantUserPermission) String() string { return Stringify(v) }
+
+// ListAvailablePermissions lists available permissions that can be assigned to users within a tenant.
+func (s *TenantUsersService) ListAvailablePermissions(ctx context.Context, tenantID string) ([]TenantUserPermission, *Response, error) {
+	if tenantID == "" {
+		return nil, nil, fmt.Errorf("tenant id: %w", ErrEmptyArgument)
+	}
+
+	path := fmt.Sprintf("%v/permissions", fmt.Sprintf(tenantUsersBasePath, tenantID))
+	req, err := s.client.NewRequest(http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var permissions []TenantUserPermission
+	resp, err := s.client.Do(ctx, req, &permissions)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return permissions, resp, nil
+}
+
+// UpdatePermissions updates roles and permissions for a tenant user.
+func (s *TenantUsersService) UpdatePermissions(ctx context.Context, tenantID, userID string, updateRequest *TenantUserPermissionsUpdateRequest) (*Response, error) {
+	if tenantID == "" {
+		return nil, fmt.Errorf("tenant id: %w", ErrEmptyArgument)
+	}
+	if userID == "" {
+		return nil, fmt.Errorf("user id: %w", ErrEmptyArgument)
+	}
+	if updateRequest == nil {
+		return nil, fmt.Errorf("payload: %w", ErrEmptyPayloadNotAllowed)
+	}
+
+	path := fmt.Sprintf("%v/%v/permissions", fmt.Sprintf(tenantUsersBasePath, tenantID), userID)
+	req, err := s.client.NewRequest(http.MethodPost, path, updateRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(ctx, req, nil)
+}

--- a/xelon/tenant_users.go
+++ b/xelon/tenant_users.go
@@ -55,6 +55,11 @@ type TenantUserUpdateRequest struct {
 	Surname       string `json:"surname"`
 }
 
+type TenantUserPasswordUpdateRequest struct {
+	Password             string `json:"password"`
+	PasswordConfirmation string `json:"password_confirmation"`
+}
+
 // TenantUserListOptions specifies the optional parameters to the TenantUsersService.List.
 type TenantUserListOptions struct {
 	Search string `url:"search,omitempty"`
@@ -113,7 +118,7 @@ func (s *TenantUsersService) Get(ctx context.Context, tenantID, userID string) (
 		return nil, nil, fmt.Errorf("user id: %w", ErrEmptyArgument)
 	}
 
-	path := fmt.Sprintf("%v/%v", fmt.Sprintf(tenantUsersBasePath, tenantID), userID)
+	path := fmt.Sprintf(tenantUsersBasePath+"/%s", tenantID, userID)
 	req, err := s.client.NewRequest(http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
@@ -169,7 +174,7 @@ func (s *TenantUsersService) Update(ctx context.Context, tenantID, userID string
 		return nil, nil, fmt.Errorf("payload: %w", ErrEmptyPayloadNotAllowed)
 	}
 
-	path := fmt.Sprintf("%v/%v", fmt.Sprintf(tenantUsersBasePath, tenantID), userID)
+	path := fmt.Sprintf(tenantUsersBasePath+"/%s", tenantID, userID)
 	req, err := s.client.NewRequest(http.MethodPut, path, updateRequest)
 	if err != nil {
 		return nil, nil, err
@@ -196,8 +201,52 @@ func (s *TenantUsersService) Delete(ctx context.Context, tenantID, userID string
 		return nil, fmt.Errorf("user id: %w", ErrEmptyArgument)
 	}
 
-	path := fmt.Sprintf("%v/%v", fmt.Sprintf(tenantUsersBasePath, tenantID), userID)
+	path := fmt.Sprintf(tenantUsersBasePath+"/%s", tenantID, userID)
 	req, err := s.client.NewRequest(http.MethodDelete, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(ctx, req, nil)
+}
+
+// Restore restores a previously deleted tenant user.
+func (s *TenantUsersService) Restore(ctx context.Context, tenantID, userID string) (*Response, error) {
+	if tenantID == "" {
+		return nil, fmt.Errorf("tenant id: %w", ErrEmptyArgument)
+	}
+	if userID == "" {
+		return nil, fmt.Errorf("user id: %w", ErrEmptyArgument)
+	}
+
+	restoreRequest := struct {
+		UserID string `json:"userIdentifier"`
+	}{
+		UserID: userID,
+	}
+	path := fmt.Sprintf(tenantUsersBasePath+"/restore", tenantID)
+	req, err := s.client.NewRequest(http.MethodPost, path, restoreRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(ctx, req, nil)
+}
+
+// UpdatePassword updates a tenant user's password.
+func (s *TenantUsersService) UpdatePassword(ctx context.Context, tenantID, userID string, updateRequest *TenantUserPasswordUpdateRequest) (*Response, error) {
+	if tenantID == "" {
+		return nil, fmt.Errorf("tenant id: %w", ErrEmptyArgument)
+	}
+	if userID == "" {
+		return nil, fmt.Errorf("user id: %w", ErrEmptyArgument)
+	}
+	if updateRequest == nil {
+		return nil, fmt.Errorf("payload: %w", ErrEmptyPayloadNotAllowed)
+	}
+
+	path := fmt.Sprintf(tenantUsersBasePath+"/%s/password", tenantID, userID)
+	req, err := s.client.NewRequest(http.MethodPost, path, updateRequest)
 	if err != nil {
 		return nil, err
 	}
@@ -226,7 +275,7 @@ func (s *TenantUsersService) ListAvailablePermissions(ctx context.Context, tenan
 		return nil, nil, fmt.Errorf("tenant id: %w", ErrEmptyArgument)
 	}
 
-	path := fmt.Sprintf("%v/permissions", fmt.Sprintf(tenantUsersBasePath, tenantID))
+	path := fmt.Sprintf(tenantUsersBasePath+"/permissions", tenantID)
 	req, err := s.client.NewRequest(http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
@@ -253,7 +302,7 @@ func (s *TenantUsersService) UpdatePermissions(ctx context.Context, tenantID, us
 		return nil, fmt.Errorf("payload: %w", ErrEmptyPayloadNotAllowed)
 	}
 
-	path := fmt.Sprintf("%v/%v/permissions", fmt.Sprintf(tenantUsersBasePath, tenantID), userID)
+	path := fmt.Sprintf(tenantUsersBasePath+"/%s/permissions", tenantID, userID)
 	req, err := s.client.NewRequest(http.MethodPost, path, updateRequest)
 	if err != nil {
 		return nil, err

--- a/xelon/tenant_users_test.go
+++ b/xelon/tenant_users_test.go
@@ -211,6 +211,56 @@ func TestTenantUsers_Delete(t *testing.T) {
 	assert.NotNil(t, resp)
 }
 
+func TestTenantUsers_Restore(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("POST /tenants/tenant-1/users/restore", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+
+		body, err := io.ReadAll(r.Body)
+		assert.NoError(t, err)
+		assert.JSONEq(t, `{
+			"userIdentifier": "user-1"
+		}`, string(body))
+
+		fixture := loadFixture(t, "tenantusers_restore_user_success.json")
+		_, _ = w.Write(fixture)
+	})
+
+	resp, err := client.TenantUsers.Restore(ctx, "tenant-1", "user-1")
+
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+}
+
+func TestTenantUsers_UpdatePassword(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("POST /tenants/tenant-1/users/user-1/password", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+
+		body, err := io.ReadAll(r.Body)
+		assert.NoError(t, err)
+		assert.JSONEq(t, `{
+			"password": "NewSecurePass123!",
+			"password_confirmation": "NewSecurePass123!"
+		}`, string(body))
+
+		fixture := loadFixture(t, "tenantusers_update_password_success.json")
+		_, _ = w.Write(fixture)
+	})
+
+	resp, err := client.TenantUsers.UpdatePassword(ctx, "tenant-1", "user-1", &TenantUserPasswordUpdateRequest{
+		Password:             "NewSecurePass123!",
+		PasswordConfirmation: "NewSecurePass123!",
+	})
+
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+}
+
 func TestTenantUsers_ListAvailablePermissions(t *testing.T) {
 	setup()
 	defer teardown()
@@ -385,6 +435,41 @@ func TestTenantUsers_ValidationErrors(t *testing.T) {
 				return err
 			},
 			target: ErrEmptyArgument,
+		},
+		"restore empty tenant id": {
+			request: func() error {
+				_, err := client.TenantUsers.Restore(ctx, "", "user-1")
+				return err
+			},
+			target: ErrEmptyArgument,
+		},
+		"restore empty user id": {
+			request: func() error {
+				_, err := client.TenantUsers.Restore(ctx, "tenant-1", "")
+				return err
+			},
+			target: ErrEmptyArgument,
+		},
+		"update password empty tenant id": {
+			request: func() error {
+				_, err := client.TenantUsers.UpdatePassword(ctx, "", "user-1", &TenantUserPasswordUpdateRequest{})
+				return err
+			},
+			target: ErrEmptyArgument,
+		},
+		"update password empty user id": {
+			request: func() error {
+				_, err := client.TenantUsers.UpdatePassword(ctx, "tenant-1", "", &TenantUserPasswordUpdateRequest{})
+				return err
+			},
+			target: ErrEmptyArgument,
+		},
+		"update password nil payload": {
+			request: func() error {
+				_, err := client.TenantUsers.UpdatePassword(ctx, "tenant-1", "user-1", nil)
+				return err
+			},
+			target: ErrEmptyPayloadNotAllowed,
 		},
 		"list available permissions empty tenant id": {
 			request: func() error {

--- a/xelon/tenant_users_test.go
+++ b/xelon/tenant_users_test.go
@@ -1,0 +1,427 @@
+package xelon
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTenantUsers_List(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("GET /tenants/tenant-1/users", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "john", r.URL.Query().Get("search"))
+		fixture := loadFixture(t, "tenantusers_list_users.json")
+		_, _ = w.Write(fixture)
+	})
+	expectedUsers := []TenantUser{{
+		Email:    "john.doe@example.com",
+		ID:       "user-1",
+		JobTitle: "sysadmin_devops",
+		Name:     "John",
+		Surname:  "Doe",
+		TenantID: "tenant-1",
+	}, {
+		Email:    "jane.doe@example.com",
+		ID:       "user-2",
+		JobTitle: "ceo",
+		Name:     "Jane",
+		Surname:  "Doe",
+		TenantID: "tenant-1",
+	}}
+
+	actualUsers, resp, err := client.TenantUsers.List(ctx, "tenant-1", &TenantUserListOptions{Search: "john"})
+
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.Equal(t, expectedUsers, actualUsers)
+	assert.Equal(t, &Meta{
+		Total:    3,
+		LastPage: 2,
+		PerPage:  2,
+		Page:     1,
+		From:     1,
+		To:       2,
+	}, resp.Meta)
+}
+
+func TestTenantUsers_Get(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("GET /tenants/tenant-1/users/user-1", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		fixture := loadFixture(t, "tenantusers_get_user_success.json")
+		_, _ = w.Write(fixture)
+	})
+	expectedUser := &TenantUser{
+		Email:    "john.doe@example.com",
+		ID:       "user-1",
+		JobTitle: "developer",
+		Name:     "John",
+		Permissions: []TenantUserPermission{{
+			DisplayName: "Allow view virtual machines",
+			ID:          75,
+			Name:        "allow_view_virtual_machines",
+			Type:        "virtual_machine",
+		}},
+		Roles: []TenantUserRole{{
+			DisplayName: "Organization Admin",
+			ID:          1,
+			Name:        "hq_organization_admin",
+			Type:        "organization",
+		}},
+		Surname:  "Doe",
+		TenantID: "tenant-1",
+	}
+
+	actualUser, resp, err := client.TenantUsers.Get(ctx, "tenant-1", "user-1")
+
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.Equal(t, expectedUser, actualUser)
+}
+
+func TestTenantUsers_Create(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("POST /tenants/tenant-1/users", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+
+		body, err := io.ReadAll(r.Body)
+		assert.NoError(t, err)
+		assert.JSONEq(t, `{
+			"name": "John",
+			"surname": "Doe",
+			"email": "john.doe@example.com",
+			"password": "SecurePass123!",
+			"password_confirmation": "SecurePass123!",
+			"job_title": "developer",
+			"passwordShouldBeChanged": false,
+			"welcomeEmail": true,
+			"roles": ["hq_organization_admin"],
+			"permissions": ["allow_view_virtual_machines"]
+		}`, string(body))
+
+		var actualRequest TenantUserCreateRequest
+		err = json.Unmarshal(body, &actualRequest)
+		assert.NoError(t, err)
+		assert.Equal(t, TenantUserCreateRequest{
+			Email:                 "john.doe@example.com",
+			JobTitle:              "developer",
+			Name:                  "John",
+			Password:              "SecurePass123!",
+			PasswordConfirmation:  "SecurePass123!",
+			Permissions:           []string{"allow_view_virtual_machines"},
+			RequirePasswordChange: false,
+			Roles:                 []string{"hq_organization_admin"},
+			SendWelcomeEmail:      true,
+			Surname:               "Doe",
+		}, actualRequest)
+
+		fixture := loadFixture(t, "tenantusers_create_user_success.json")
+		_, _ = w.Write(fixture)
+	})
+	expectedUser := &TenantUser{
+		Email:    "john.doe@example.com",
+		ID:       "user-1",
+		JobTitle: "developer",
+		Name:     "John",
+		Surname:  "Doe",
+		TenantID: "tenant-1",
+	}
+
+	actualUser, resp, err := client.TenantUsers.Create(ctx, "tenant-1", &TenantUserCreateRequest{
+		Email:                 "john.doe@example.com",
+		JobTitle:              "developer",
+		Name:                  "John",
+		Password:              "SecurePass123!",
+		PasswordConfirmation:  "SecurePass123!",
+		Permissions:           []string{"allow_view_virtual_machines"},
+		RequirePasswordChange: false,
+		Roles:                 []string{"hq_organization_admin"},
+		SendWelcomeEmail:      true,
+		Surname:               "Doe",
+	})
+
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.Equal(t, expectedUser, actualUser)
+}
+
+func TestTenantUsers_Update(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("PUT /tenants/tenant-1/users/user-1", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method)
+
+		var actualRequest TenantUserUpdateRequest
+		err := json.NewDecoder(r.Body).Decode(&actualRequest)
+		assert.NoError(t, err)
+		assert.Equal(t, TenantUserUpdateRequest{
+			JobTitle: "developer",
+			Name:     "Jane",
+			Surname:  "Doe",
+		}, actualRequest)
+
+		fixture := loadFixture(t, "tenantusers_update_user_success.json")
+		_, _ = w.Write(fixture)
+	})
+	expectedUser := &TenantUser{
+		Email:    "jane.doe@example.com",
+		ID:       "user-1",
+		JobTitle: "developer",
+		Name:     "Jane",
+		Surname:  "Doe",
+		TenantID: "tenant-1",
+	}
+
+	actualUser, resp, err := client.TenantUsers.Update(ctx, "tenant-1", "user-1", &TenantUserUpdateRequest{
+		JobTitle: "developer",
+		Name:     "Jane",
+		Surname:  "Doe",
+	})
+
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.Equal(t, expectedUser, actualUser)
+}
+
+func TestTenantUsers_Delete(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("DELETE /tenants/tenant-1/users/user-1", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		fixture := loadFixture(t, "tenantusers_delete_user_success.json")
+		_, _ = w.Write(fixture)
+	})
+
+	resp, err := client.TenantUsers.Delete(ctx, "tenant-1", "user-1")
+
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+}
+
+func TestTenantUsers_ListAvailablePermissions(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("GET /tenants/tenant-1/users/permissions", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		fixture := loadFixture(t, "tenantusers_list_available_permissions.json")
+		_, _ = w.Write(fixture)
+	})
+	expectedPermissions := []TenantUserPermission{{
+		DisplayName: "View Virtual Machines",
+		ID:          1,
+		Name:        "allow_view_virtual_machines",
+		Type:        "virtual_machines",
+	}}
+
+	actualPermissions, resp, err := client.TenantUsers.ListAvailablePermissions(ctx, "tenant-1")
+
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.Equal(t, expectedPermissions, actualPermissions)
+}
+
+func TestTenantUsers_UpdatePermissions(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("POST /tenants/tenant-1/users/user-1/permissions", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+
+		var actualRequest TenantUserPermissionsUpdateRequest
+		err := json.NewDecoder(r.Body).Decode(&actualRequest)
+		assert.NoError(t, err)
+		assert.Equal(t, TenantUserPermissionsUpdateRequest{
+			ChildTenants: []string{"child-tenant-1"},
+			Permissions:  []string{"allow_view_virtual_machines"},
+			Roles:        []string{"hq_organization_admin"},
+		}, actualRequest)
+
+		fixture := loadFixture(t, "tenantusers_update_permissions_success.json")
+		_, _ = w.Write(fixture)
+	})
+
+	resp, err := client.TenantUsers.UpdatePermissions(ctx, "tenant-1", "user-1", &TenantUserPermissionsUpdateRequest{
+		ChildTenants: []string{"child-tenant-1"},
+		Permissions:  []string{"allow_view_virtual_machines"},
+		Roles:        []string{"hq_organization_admin"},
+	})
+
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+}
+
+func TestTenantUsers_MissingData(t *testing.T) {
+	setup()
+	defer teardown()
+
+	tests := map[string]struct {
+		request func() (*TenantUser, *Response, error)
+	}{
+		"get": {
+			request: func() (*TenantUser, *Response, error) {
+				return client.TenantUsers.Get(ctx, "tenant-1", "user-1")
+			},
+		},
+		"create": {
+			request: func() (*TenantUser, *Response, error) {
+				return client.TenantUsers.Create(ctx, "tenant-1", &TenantUserCreateRequest{})
+			},
+		},
+		"update": {
+			request: func() (*TenantUser, *Response, error) {
+				return client.TenantUsers.Update(ctx, "tenant-1", "user-1", &TenantUserUpdateRequest{})
+			},
+		},
+	}
+
+	mux.HandleFunc("GET /tenants/tenant-1/users/user-1", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"message":"missing data"}`))
+	})
+	mux.HandleFunc("POST /tenants/tenant-1/users", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"data":null,"message":"missing data"}`))
+	})
+	mux.HandleFunc("PUT /tenants/tenant-1/users/user-1", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"data":null,"message":"missing data"}`))
+	})
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			actualUser, resp, err := test.request()
+
+			assert.Nil(t, actualUser)
+			assert.NotNil(t, resp)
+			assert.EqualError(t, err, "tenant user data is empty")
+		})
+	}
+}
+
+func TestTenantUsers_ValidationErrors(t *testing.T) {
+	client := NewClient("auth-token")
+
+	tests := map[string]struct {
+		request func() error
+		target  error
+	}{
+		"list empty tenant id": {
+			request: func() error {
+				_, _, err := client.TenantUsers.List(ctx, "", nil)
+				return err
+			},
+			target: ErrEmptyArgument,
+		},
+		"get empty tenant id": {
+			request: func() error {
+				_, _, err := client.TenantUsers.Get(ctx, "", "user-1")
+				return err
+			},
+			target: ErrEmptyArgument,
+		},
+		"get empty user id": {
+			request: func() error {
+				_, _, err := client.TenantUsers.Get(ctx, "tenant-1", "")
+				return err
+			},
+			target: ErrEmptyArgument,
+		},
+		"create empty tenant id": {
+			request: func() error {
+				_, _, err := client.TenantUsers.Create(ctx, "", &TenantUserCreateRequest{})
+				return err
+			},
+			target: ErrEmptyArgument,
+		},
+		"create nil payload": {
+			request: func() error {
+				_, _, err := client.TenantUsers.Create(ctx, "tenant-1", nil)
+				return err
+			},
+			target: ErrEmptyPayloadNotAllowed,
+		},
+		"update empty tenant id": {
+			request: func() error {
+				_, _, err := client.TenantUsers.Update(ctx, "", "user-1", &TenantUserUpdateRequest{})
+				return err
+			},
+			target: ErrEmptyArgument,
+		},
+		"update empty user id": {
+			request: func() error {
+				_, _, err := client.TenantUsers.Update(ctx, "tenant-1", "", &TenantUserUpdateRequest{})
+				return err
+			},
+			target: ErrEmptyArgument,
+		},
+		"update nil payload": {
+			request: func() error {
+				_, _, err := client.TenantUsers.Update(ctx, "tenant-1", "user-1", nil)
+				return err
+			},
+			target: ErrEmptyPayloadNotAllowed,
+		},
+		"delete empty tenant id": {
+			request: func() error {
+				_, err := client.TenantUsers.Delete(ctx, "", "user-1")
+				return err
+			},
+			target: ErrEmptyArgument,
+		},
+		"delete empty user id": {
+			request: func() error {
+				_, err := client.TenantUsers.Delete(ctx, "tenant-1", "")
+				return err
+			},
+			target: ErrEmptyArgument,
+		},
+		"list available permissions empty tenant id": {
+			request: func() error {
+				_, _, err := client.TenantUsers.ListAvailablePermissions(ctx, "")
+				return err
+			},
+			target: ErrEmptyArgument,
+		},
+		"update permissions empty tenant id": {
+			request: func() error {
+				_, err := client.TenantUsers.UpdatePermissions(ctx, "", "user-1", &TenantUserPermissionsUpdateRequest{})
+				return err
+			},
+			target: ErrEmptyArgument,
+		},
+		"update permissions empty user id": {
+			request: func() error {
+				_, err := client.TenantUsers.UpdatePermissions(ctx, "tenant-1", "", &TenantUserPermissionsUpdateRequest{})
+				return err
+			},
+			target: ErrEmptyArgument,
+		},
+		"update permissions nil payload": {
+			request: func() error {
+				_, err := client.TenantUsers.UpdatePermissions(ctx, "tenant-1", "user-1", nil)
+				return err
+			},
+			target: ErrEmptyPayloadNotAllowed,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := test.request()
+
+			assert.Error(t, err)
+			assert.True(t, errors.Is(err, test.target))
+		})
+	}
+}

--- a/xelon/testdata/tenantusers_create_user_success.json
+++ b/xelon/testdata/tenantusers_create_user_success.json
@@ -1,0 +1,11 @@
+{
+  "data": {
+    "identifier": "user-1",
+    "name": "John",
+    "surname": "Doe",
+    "email": "john.doe@example.com",
+    "jobTitle": "developer",
+    "tenantIdentifier": "tenant-1"
+  },
+  "message": "User successfully added."
+}

--- a/xelon/testdata/tenantusers_delete_user_success.json
+++ b/xelon/testdata/tenantusers_delete_user_success.json
@@ -1,0 +1,3 @@
+{
+  "message": "User has been deactivated."
+}

--- a/xelon/testdata/tenantusers_get_user_success.json
+++ b/xelon/testdata/tenantusers_get_user_success.json
@@ -1,0 +1,26 @@
+{
+  "data": {
+    "identifier": "user-1",
+    "name": "John",
+    "surname": "Doe",
+    "email": "john.doe@example.com",
+    "jobTitle": "developer",
+    "tenantIdentifier": "tenant-1",
+    "roles": [
+      {
+        "id": 1,
+        "name": "hq_organization_admin",
+        "friendlyName": "Organization Admin",
+        "type": "organization"
+      }
+    ],
+    "permissions": [
+      {
+        "id": 75,
+        "name": "allow_view_virtual_machines",
+        "friendlyName": "Allow view virtual machines",
+        "type": "virtual_machine"
+      }
+    ]
+  }
+}

--- a/xelon/testdata/tenantusers_list_available_permissions.json
+++ b/xelon/testdata/tenantusers_list_available_permissions.json
@@ -1,0 +1,8 @@
+[
+  {
+    "id": 1,
+    "name": "allow_view_virtual_machines",
+    "friendlyName": "View Virtual Machines",
+    "type": "virtual_machines"
+  }
+]

--- a/xelon/testdata/tenantusers_list_users.json
+++ b/xelon/testdata/tenantusers_list_users.json
@@ -1,0 +1,28 @@
+{
+  "data": [
+    {
+      "identifier": "user-1",
+      "name": "John",
+      "surname": "Doe",
+      "email": "john.doe@example.com",
+      "jobTitle": "sysadmin_devops",
+      "tenantIdentifier": "tenant-1"
+    },
+    {
+      "identifier": "user-2",
+      "name": "Jane",
+      "surname": "Doe",
+      "email": "jane.doe@example.com",
+      "jobTitle": "ceo",
+      "tenantIdentifier": "tenant-1"
+    }
+  ],
+  "meta": {
+    "total": 3,
+    "lastPage": 2,
+    "perPage": 2,
+    "currentPage": 1,
+    "from": 1,
+    "to": 2
+  }
+}

--- a/xelon/testdata/tenantusers_restore_user_success.json
+++ b/xelon/testdata/tenantusers_restore_user_success.json
@@ -1,0 +1,3 @@
+{
+  "message": "User has been restored."
+}

--- a/xelon/testdata/tenantusers_update_password_success.json
+++ b/xelon/testdata/tenantusers_update_password_success.json
@@ -1,0 +1,3 @@
+{
+  "message": "Password has been changed."
+}

--- a/xelon/testdata/tenantusers_update_permissions_success.json
+++ b/xelon/testdata/tenantusers_update_permissions_success.json
@@ -1,0 +1,3 @@
+{
+  "message": "User permissions successfully updated."
+}

--- a/xelon/testdata/tenantusers_update_user_success.json
+++ b/xelon/testdata/tenantusers_update_user_success.json
@@ -1,0 +1,11 @@
+{
+  "data": {
+    "identifier": "user-1",
+    "name": "Jane",
+    "surname": "Doe",
+    "email": "jane.doe@example.com",
+    "jobTitle": "developer",
+    "tenantIdentifier": "tenant-1"
+  },
+  "message": "User updated successfully."
+}


### PR DESCRIPTION
This PR adds a new service `TenantUsers` to manage tenant users and their permissions.