### PR TITLE
fix(domains): add createAt field to dns zone

### DIFF
--- a/xelon/domains.go
+++ b/xelon/domains.go
@@ -2,9 +2,11 @@ package xelon
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"iter"
 	"net/http"
+	"time"
 )
 
 const dnsBasePath = "dns"
@@ -14,9 +16,10 @@ type DomainsService service
 
 // DNSZone represents a Xelon DNS zone.
 type DNSZone struct {
-	ID        string `json:"identifier,omitempty"`
-	Name      string `json:"name,omitempty"`
-	OwnerName string `json:"ownerName,omitempty"`
+	CreatedAt *time.Time `json:"createdAt,omitempty"`
+	ID        string     `json:"identifier,omitempty"`
+	Name      string     `json:"name,omitempty"`
+	OwnerName string     `json:"ownerName,omitempty"`
 }
 
 type DNSZoneCreateRequest struct {
@@ -109,6 +112,9 @@ func (s *DomainsService) CreateZone(ctx context.Context, createRequest *DNSZoneC
 	resp, err := s.client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
+	}
+	if root.DNSZone == nil {
+		return nil, resp, errors.New("dns zone data is empty")
 	}
 
 	return root.DNSZone, resp, nil

--- a/xelon/domains_test.go
+++ b/xelon/domains_test.go
@@ -19,10 +19,12 @@ func TestDomains_ListZones(t *testing.T) {
 		_, _ = w.Write(fixture)
 	})
 	expectedZones := []DNSZone{{
+		CreatedAt: mustTime(t, "2024-01-01T12:00:00Z"),
 		ID:        "dns-zone-1",
 		Name:      "example.com",
 		OwnerName: "test-tenant",
 	}, {
+		CreatedAt: mustTime(t, "2024-01-02T12:00:00Z"),
 		ID:        "dns-zone-2",
 		Name:      "example.net",
 		OwnerName: "test-tenant",
@@ -53,6 +55,7 @@ func TestDomains_GetZone(t *testing.T) {
 		_, _ = w.Write(fixture)
 	})
 	expectedZone := &DNSZone{
+		CreatedAt: mustTime(t, "2024-01-01T12:00:00Z"),
 		ID:        "dns-zone-1",
 		Name:      "example.com",
 		OwnerName: "test-tenant",
@@ -81,6 +84,7 @@ func TestDomains_CreateZone(t *testing.T) {
 		_, _ = w.Write(fixture)
 	})
 	expectedZone := &DNSZone{
+		CreatedAt: mustTime(t, "2024-01-01T12:00:00Z"),
 		ID:        "dns-zone-1",
 		Name:      "example.com",
 		OwnerName: "test-tenant",
@@ -91,6 +95,41 @@ func TestDomains_CreateZone(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
 	assert.Equal(t, expectedZone, actualZone)
+}
+
+func TestDomains_CreateZone_MissingData(t *testing.T) {
+	setup()
+	defer teardown()
+
+	type testCase struct {
+		responseBody string
+	}
+	tests := map[string]testCase{
+		"missing data": {
+			responseBody: `{"message":"DNS zone created successfully."}`,
+		},
+		"null data": {
+			responseBody: `{"data":null,"message":"DNS zone created successfully."}`,
+		},
+	}
+
+	var responseBody string
+	mux.HandleFunc("POST /dns", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		_, _ = w.Write([]byte(responseBody))
+	})
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			responseBody = test.responseBody
+
+			actualZone, resp, err := client.Domains.CreateZone(ctx, &DNSZoneCreateRequest{Domain: "example.com"})
+
+			assert.Nil(t, actualZone)
+			assert.NotNil(t, resp)
+			assert.EqualError(t, err, "dns zone data is empty")
+		})
+	}
 }
 
 func TestDomains_DeleteZone(t *testing.T) {

--- a/xelon/testdata/domains_create_zone_success.json
+++ b/xelon/testdata/domains_create_zone_success.json
@@ -1,5 +1,6 @@
 {
   "data": {
+    "createdAt": "2024-01-01T12:00:00Z",
     "identifier": "dns-zone-1",
     "name": "example.com",
     "ownerName": "test-tenant"

--- a/xelon/testdata/domains_get_zone_success.json
+++ b/xelon/testdata/domains_get_zone_success.json
@@ -1,4 +1,5 @@
 {
+  "createdAt": "2024-01-01T12:00:00Z",
   "identifier": "dns-zone-1",
   "name": "example.com",
   "ownerName": "test-tenant"

--- a/xelon/testdata/domains_list_zones.json
+++ b/xelon/testdata/domains_list_zones.json
@@ -1,11 +1,13 @@
 {
   "data": [
     {
+      "createdAt": "2024-01-01T12:00:00Z",
       "identifier": "dns-zone-1",
       "name": "example.com",
       "ownerName": "test-tenant"
     },
     {
+      "createdAt": "2024-01-02T12:00:00Z",
       "identifier": "dns-zone-2",
       "name": "example.net",
       "ownerName": "test-tenant"


### PR DESCRIPTION
This PR adds `createdAt` field to DNSZone struct.