### PR TITLE
fix(object-storage): add retention days field for object lock

### DIFF
--- a/xelon/object_storages.go
+++ b/xelon/object_storages.go
@@ -232,12 +232,14 @@ func (s *ObjectStoragesService) DeleteUserToken(ctx context.Context, objectStora
 	return s.client.Do(ctx, req, nil)
 }
 
+// ObjectStorageBucket represents a Xelon bucket for S3-compatible object storage.
 type ObjectStorageBucket struct {
 	CreatedAt                *time.Time `json:"createdAt,omitempty"`
 	ID                       string     `json:"identifier"`
 	IPRestrictionsEnabled    bool       `json:"isWithRestrictedIps,omitempty"`
 	Name                     string     `json:"name,omitempty"`
 	ObjectLockEnabled        bool       `json:"isObjectLock,omitempty"`
+	ObjectLockRetentionDays  int        `json:"retentionPeriodDays,omitempty"`
 	ObjectStorageUserID      string     `json:"s3UserIdentifier,omitempty"`
 	ObjectStorageUserName    string     `json:"s3UserName,omitempty"`
 	RegionName               string     `json:"zoneGroup,omitempty"`

--- a/xelon/object_storages.go
+++ b/xelon/object_storages.go
@@ -345,16 +345,16 @@ func (s *ObjectStoragesService) GetBucket(ctx context.Context, bucketName, objec
 		return nil, nil, err
 	}
 
-	bucket := new(ObjectStorageBucket)
-	resp, err := s.client.Do(ctx, req, bucket)
+	root := new(objectStorageBucketRoot)
+	resp, err := s.client.Do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
-	if bucket.ID == "" && bucket.Name == "" {
+	if root.ObjectStorageBucket == nil {
 		return nil, resp, errors.New("object storage bucket data is empty")
 	}
 
-	return bucket, resp, nil
+	return root.ObjectStorageBucket, resp, nil
 }
 
 // CreateBucket makes a new object storage bucket with given payload.

--- a/xelon/object_storages_test.go
+++ b/xelon/object_storages_test.go
@@ -250,6 +250,7 @@ func TestObjectStorages_ListBuckets(t *testing.T) {
 		IPRestrictionsEnabled:    true,
 		Name:                     "test-bucket-0",
 		ObjectLockEnabled:        false,
+		ObjectLockRetentionDays:  0,
 		ObjectStorageUserID:      "00000000-0000-0000-0000-000000000000",
 		ObjectStorageUserName:    "test-user-0",
 		RegionName:               "Aargau",
@@ -263,6 +264,7 @@ func TestObjectStorages_ListBuckets(t *testing.T) {
 		IPRestrictionsEnabled:    false,
 		Name:                     "test-bucket-1",
 		ObjectLockEnabled:        true,
+		ObjectLockRetentionDays:  90,
 		ObjectStorageUserID:      "11111111-1111-1111-1111-111111111111",
 		ObjectStorageUserName:    "test-user-1",
 		RegionName:               "Zurich",
@@ -345,6 +347,7 @@ func TestObjectStorages_GetBucket(t *testing.T) {
 		IPRestrictionsEnabled:    true,
 		Name:                     "test-bucket-0",
 		ObjectLockEnabled:        false,
+		ObjectLockRetentionDays:  0,
 		ObjectStorageUserID:      "00000000-0000-0000-0000-000000000000",
 		ObjectStorageUserName:    "test-user-0",
 		RegionName:               "Aargau",
@@ -403,6 +406,7 @@ func TestObjectStorages_CreateBucket(t *testing.T) {
 		IPRestrictionsEnabled:    false,
 		Name:                     "test-bucket-0",
 		ObjectLockEnabled:        false,
+		ObjectLockRetentionDays:  30,
 		ObjectStorageUserID:      "00000000-0000-0000-0000-000000000000",
 		ObjectStorageUserName:    "test-user-0",
 		RegionName:               "Aargau",
@@ -423,6 +427,22 @@ func TestObjectStorages_CreateBucket(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
 	assert.Equal(t, expectedBucket, actualBucket)
+}
+
+func TestObjectStorages_CreateBucket_ZeroObjectLockRetentionDaysOmitted(t *testing.T) {
+	actualRequest, err := json.Marshal(ObjectStorageBucketCreateRequest{
+		Name:                    "test-bucket-0",
+		ObjectLockEnabled:       true,
+		ObjectLockRetentionDays: 0,
+		ObjectStorageUserID:     "00000000-0000-0000-0000-000000000000",
+		VersioningEnabled:       true,
+	})
+	assert.NoError(t, err)
+
+	var payload map[string]any
+	err = json.Unmarshal(actualRequest, &payload)
+	assert.NoError(t, err)
+	assert.NotContains(t, payload, "retentionPeriodDays")
 }
 
 func TestObjectStorages_CreateBucket_MissingData(t *testing.T) {

--- a/xelon/object_storages_test.go
+++ b/xelon/object_storages_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestObjectStorages_ListUsers(t *testing.T) {
@@ -359,7 +360,7 @@ func TestObjectStorages_GetBucket(t *testing.T) {
 
 	actualBucket, resp, err := client.ObjectStorages.GetBucket(ctx, "test-bucket-0", "00000000-0000-0000-0000-000000000000")
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, resp)
 	assert.Equal(t, expectedBucket, actualBucket)
 }

--- a/xelon/testdata/objectstorages_create_bucket_success.json
+++ b/xelon/testdata/objectstorages_create_bucket_success.json
@@ -12,6 +12,7 @@
       "name": "test-tenant-0"
     },
     "isObjectLock": false,
+    "retentionPeriodDays": 30,
     "isVersioning": true,
     "s3endpoints": [
       "https:\/\/ch1-s3.xelon.io"

--- a/xelon/testdata/objectstorages_get_bucket_success.json
+++ b/xelon/testdata/objectstorages_get_bucket_success.json
@@ -1,19 +1,22 @@
 {
-  "identifier": "zone1.4711.1",
-  "name": "test-bucket-0",
-  "createdAt": "2025-10-27T14:19:56+01:00",
-  "zoneGroup": "Aargau",
-  "isReplicated": true,
-  "s3UserName": "test-user-0",
-  "s3UserIdentifier": "00000000-0000-0000-0000-000000000000",
-  "tenant": {
-    "identifier": "000000000",
-    "name": "test-tenant-0"
-  },
-  "isObjectLock": false,
-  "isVersioning": true,
-  "s3endpoints": [
-    "https:\/\/ch1-s3.xelon.io"
-  ],
-  "isWithRestrictedIps": true
+  "data": {
+    "identifier": "zone1.4711.1",
+    "name": "test-bucket-0",
+    "createdAt": "2025-10-27T14:19:56+01:00",
+    "zoneGroup": "Aargau",
+    "isReplicated": true,
+    "s3UserName": "test-user-0",
+    "s3UserIdentifier": "00000000-0000-0000-0000-000000000000",
+    "tenant": {
+      "identifier": "000000000",
+      "name": "test-tenant-0"
+    },
+    "isObjectLock": false,
+    "retentionPeriodDays": 0,
+    "isVersioning": true,
+    "s3endpoints": [
+      "https:\/\/ch1-s3.xelon.io"
+    ],
+    "isWithRestrictedIps": true
+  }
 }

--- a/xelon/testdata/objectstorages_list_buckets.json
+++ b/xelon/testdata/objectstorages_list_buckets.json
@@ -13,6 +13,7 @@
         "name": "test-tenant-0"
       },
       "isObjectLock": false,
+      "retentionPeriodDays": null,
       "isVersioning": true,
       "s3endpoints": [
         "https:\/\/ch1-s3.xelon.io"
@@ -32,6 +33,7 @@
         "name": "test-tenant-1"
       },
       "isObjectLock": true,
+      "retentionPeriodDays": 90,
       "isVersioning": false,
       "s3endpoints": [
         "https:\/\/zh1-s3.xelon.io"


### PR DESCRIPTION
This PR extends `ObjectStorageBucket` struct and adds `ObjectLockRetentionDays` field by list, get and create operations.