### PR TITLE
fix(tenant-users): add phone fields to TenantUser struct

### DIFF
--- a/xelon/tenant_users.go
+++ b/xelon/tenant_users.go
@@ -14,12 +14,14 @@ type TenantUsersService service
 
 // TenantUser represents a user that belongs to a Xelon tenant.
 type TenantUser struct {
-	Email    string `json:"email,omitempty"`
-	ID       string `json:"identifier,omitempty"`
-	JobTitle string `json:"jobTitle,omitempty"`
-	Name     string `json:"name,omitempty"`
-	Surname  string `json:"surname,omitempty"`
-	TenantID string `json:"tenantIdentifier,omitempty"`
+	BusinessPhone string `json:"business_phone,omitempty"`
+	Email         string `json:"email,omitempty"`
+	ID            string `json:"identifier,omitempty"`
+	JobTitle      string `json:"jobTitle,omitempty"`
+	Name          string `json:"name,omitempty"`
+	Phone         string `json:"phone,omitempty"`
+	Surname       string `json:"surname,omitempty"`
+	TenantID      string `json:"tenantIdentifier,omitempty"`
 }
 
 // TenantUserWithDetails represents a tenant user with roles, permissions, and active state.
@@ -39,12 +41,14 @@ type TenantUserRole struct {
 }
 
 type TenantUserCreateRequest struct {
+	BusinessPhone         string   `json:"businessPhone,omitempty"`
 	Email                 string   `json:"email"`
-	JobTitle              string   `json:"job_title,omitempty"`
+	JobTitle              string   `json:"jobTitle,omitempty"`
 	Name                  string   `json:"name"`
 	Password              string   `json:"password"`
-	PasswordConfirmation  string   `json:"password_confirmation"`
+	PasswordConfirmation  string   `json:"passwordConfirmation"`
 	Permissions           []string `json:"permissions,omitempty"`
+	Phone                 string   `json:"phone,omitempty"`
 	RequirePasswordChange bool     `json:"passwordShouldBeChanged"`
 	Roles                 []string `json:"roles,omitempty"`
 	SendWelcomeEmail      bool     `json:"welcomeEmail"`
@@ -52,9 +56,11 @@ type TenantUserCreateRequest struct {
 }
 
 type TenantUserUpdateRequest struct {
-	JobTitle string `json:"job_title,omitempty"`
-	Name     string `json:"name"`
-	Surname  string `json:"surname"`
+	BusinessPhone string `json:"businessPhone,omitempty"`
+	JobTitle      string `json:"jobTitle,omitempty"`
+	Name          string `json:"name"`
+	Phone         string `json:"phone,omitempty"`
+	Surname       string `json:"surname"`
 }
 
 type TenantUserPasswordUpdateRequest struct {

--- a/xelon/tenant_users_test.go
+++ b/xelon/tenant_users_test.go
@@ -22,17 +22,19 @@ func TestTenantUsers_List(t *testing.T) {
 		_, _ = w.Write(fixture)
 	})
 	expectedUsers := []TenantUser{{
-		Email:    "john.doe@example.com",
-		ID:       "user-1",
-		JobTitle: "sysadmin_devops",
-		Name:     "John",
-		Surname:  "Doe",
-		TenantID: "tenant-1",
+		BusinessPhone: "+12025550143",
+		Email:         "john.doe@example.com",
+		ID:            "user-1",
+		JobTitle:      "sysadmin_devops",
+		Name:          "John",
+		Surname:       "Doe",
+		TenantID:      "tenant-1",
 	}, {
 		Email:    "jane.doe@example.com",
 		ID:       "user-2",
 		JobTitle: "ceo",
 		Name:     "Jane",
+		Phone:    "+12025550144",
 		Surname:  "Doe",
 		TenantID: "tenant-1",
 	}}
@@ -145,9 +147,11 @@ func TestTenantUsers_Create(t *testing.T) {
 			"name": "John",
 			"surname": "Doe",
 			"email": "john.doe@example.com",
+			"phone": "+12025550145",
+			"businessPhone": "+12025550146",
 			"password": "SecurePass123!",
-			"password_confirmation": "SecurePass123!",
-			"job_title": "developer",
+			"passwordConfirmation": "SecurePass123!",
+			"jobTitle": "developer",
 			"passwordShouldBeChanged": false,
 			"welcomeEmail": true,
 			"roles": ["hq_organization_admin"],
@@ -158,12 +162,14 @@ func TestTenantUsers_Create(t *testing.T) {
 		err = json.Unmarshal(body, &actualRequest)
 		assert.NoError(t, err)
 		assert.Equal(t, TenantUserCreateRequest{
+			BusinessPhone:         "+12025550146",
 			Email:                 "john.doe@example.com",
 			JobTitle:              "developer",
 			Name:                  "John",
 			Password:              "SecurePass123!",
 			PasswordConfirmation:  "SecurePass123!",
 			Permissions:           []string{"allow_view_virtual_machines"},
+			Phone:                 "+12025550145",
 			RequirePasswordChange: false,
 			Roles:                 []string{"hq_organization_admin"},
 			SendWelcomeEmail:      true,
@@ -183,19 +189,21 @@ func TestTenantUsers_Create(t *testing.T) {
 	}
 
 	actualUser, resp, err := client.TenantUsers.Create(ctx, "tenant-1", &TenantUserCreateRequest{
+		BusinessPhone:         "+12025550146",
 		Email:                 "john.doe@example.com",
 		JobTitle:              "developer",
 		Name:                  "John",
 		Password:              "SecurePass123!",
 		PasswordConfirmation:  "SecurePass123!",
 		Permissions:           []string{"allow_view_virtual_machines"},
+		Phone:                 "+12025550145",
 		RequirePasswordChange: false,
 		Roles:                 []string{"hq_organization_admin"},
 		SendWelcomeEmail:      true,
 		Surname:               "Doe",
 	})
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, resp)
 	assert.Equal(t, expectedUser, actualUser)
 }
@@ -207,13 +215,25 @@ func TestTenantUsers_Update(t *testing.T) {
 	mux.HandleFunc("PUT /tenants/tenant-1/users/user-1", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPut, r.Method)
 
+		body, err := io.ReadAll(r.Body)
+		assert.NoError(t, err)
+		assert.JSONEq(t, `{
+			"name": "Jane",
+			"surname": "Doe",
+			"phone": "+12025550147",
+			"businessPhone": "+12025550148",
+			"jobTitle": "developer"
+		}`, string(body))
+
 		var actualRequest TenantUserUpdateRequest
-		err := json.NewDecoder(r.Body).Decode(&actualRequest)
+		err = json.Unmarshal(body, &actualRequest)
 		assert.NoError(t, err)
 		assert.Equal(t, TenantUserUpdateRequest{
-			JobTitle: "developer",
-			Name:     "Jane",
-			Surname:  "Doe",
+			BusinessPhone: "+12025550148",
+			JobTitle:      "developer",
+			Name:          "Jane",
+			Phone:         "+12025550147",
+			Surname:       "Doe",
 		}, actualRequest)
 
 		fixture := loadFixture(t, "tenantusers_update_user_success.json")
@@ -229,12 +249,14 @@ func TestTenantUsers_Update(t *testing.T) {
 	}
 
 	actualUser, resp, err := client.TenantUsers.Update(ctx, "tenant-1", "user-1", &TenantUserUpdateRequest{
-		JobTitle: "developer",
-		Name:     "Jane",
-		Surname:  "Doe",
+		BusinessPhone: "+12025550148",
+		JobTitle:      "developer",
+		Name:          "Jane",
+		Phone:         "+12025550147",
+		Surname:       "Doe",
 	})
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, resp)
 	assert.Equal(t, expectedUser, actualUser)
 }

--- a/xelon/testdata/tenantusers_get_soft_deleted_user_success.json
+++ b/xelon/testdata/tenantusers_get_soft_deleted_user_success.json
@@ -4,6 +4,8 @@
     "name": "Jane",
     "surname": "Doe",
     "email": "jane.doe@example.com",
+    "phone": null,
+    "business_phone": null,
     "jobTitle": "developer",
     "tenantIdentifier": "tenant-1",
     "isActive": false,

--- a/xelon/testdata/tenantusers_get_user_success.json
+++ b/xelon/testdata/tenantusers_get_user_success.json
@@ -4,6 +4,8 @@
     "name": "John",
     "surname": "Doe",
     "email": "john.doe@example.com",
+    "phone": null,
+    "business_phone": null,
     "jobTitle": "developer",
     "tenantIdentifier": "tenant-1",
     "isActive": true,

--- a/xelon/testdata/tenantusers_list_users.json
+++ b/xelon/testdata/tenantusers_list_users.json
@@ -5,6 +5,8 @@
       "name": "John",
       "surname": "Doe",
       "email": "john.doe@example.com",
+      "phone": null,
+      "business_phone": "+12025550143",
       "jobTitle": "sysadmin_devops",
       "tenantIdentifier": "tenant-1"
     },
@@ -13,6 +15,8 @@
       "name": "Jane",
       "surname": "Doe",
       "email": "jane.doe@example.com",
+      "phone": "+12025550144",
+      "business_phone": null,
       "jobTitle": "ceo",
       "tenantIdentifier": "tenant-1"
     }


### PR DESCRIPTION
This PR adds `Phone` and `BusinessPhone` fields to `TenantUser` struct. Backend API exposes it now.